### PR TITLE
Add React frontend and FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,52 @@
-<<<<<<< HEAD
 # Car Repair Cost Estimator
 
-A Streamlit web application that estimates car repair costs using machine learning and AI image analysis.
+This project provides multiple interfaces for estimating car repair costs using a pre‑trained machine learning model and AI image analysis.
 
-## Features
+## Contents
 
-- Manual cost estimation based on car details and damage severity
-- AI-powered image analysis using Google Gemini
-- Detailed cost breakdown (parts, labor, painting)
-- Repair timeline estimation
-- Multi-language support (French/English)
+- **Streamlit app** (`app.py`) – original UI for manual entry or photo analysis
+- **FastAPI backend** (`api.py`) exposing `/predict` and `/analyze` endpoints
+- **React frontend** (`frontend/`) built with Vite and Material‑UI
 
 ## Setup
 
-1. Clone the repository
-2. Create a virtual environment:
+1. Create a Python virtual environment and install dependencies:
    ```bash
    python -m venv .venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-   ```
-3. Install dependencies:
-   ```bash
+   source .venv/bin/activate
    pip install -r requirements.txt
    ```
-4. Create a `.env` file with your Google Gemini API key:
+2. Create a `.env` file with your Google Gemini API key:
    ```
-   GEMINI_API_KEY=your_api_key_here
+   GEMINI_API_KEY=your_api_key
    ```
-
-## Running the Application
-
-1. Activate your virtual environment
-2. Run the Streamlit app:
+3. (Optional) install Node dependencies for the React app *(requires internet access)*:
    ```bash
-   streamlit run app.py
+   cd frontend
+   npm install
+   npm run dev
    ```
 
-## Deployment Options
+## Running the Backend
 
-### Option 1: Streamlit Cloud (Recommended)
-1. Create a Streamlit Cloud account
-2. Connect your GitHub repository
-3. Set environment variables (GEMINI_API_KEY)
-4. Deploy
+Start the FastAPI server:
 
-### Option 2: Heroku
-1. Create a `Procfile`:
-   ```
-   web: streamlit run app.py --server.port $PORT
-   ```
-2. Deploy using Heroku CLI
+```bash
+uvicorn api:app --reload
+```
 
-### Option 3: Local Server
-1. Install required packages
-2. Run the application
-3. Use ngrok or similar to expose the local server
+### API Endpoints
 
-## Model Files
-- `gradient_boosting_model.pkl`: Trained machine learning model
-- `preprocessor.pkl`: Data preprocessing pipeline
+- `POST /predict` – send car details as JSON to get a cost estimate
+- `POST /analyze` – upload an image (`file` field) to analyze damage and return an estimate
 
-## Note
-Make sure to keep your API keys secure and never commit them to version control. 
-=======
-# modele
- "Car Repair Cost Estimator - A Streamlit web application using machine learning and AI image analysis"
->>>>>>> origin/main
+## Running the Streamlit App
+
+You can still launch the original Streamlit interface:
+
+```bash
+streamlit run app.py
+```
+
+Both interfaces rely on the same trained model files (`gradient_boosting_model.pkl` and `preprocessor.pkl`).
+

--- a/api.py
+++ b/api.py
@@ -1,0 +1,114 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import joblib
+import pandas as pd
+from PIL import Image
+import io
+import json
+import re
+import os
+import google.generativeai as genai
+from dotenv import load_dotenv
+
+load_dotenv()
+API_KEY = os.getenv("GEMINI_API_KEY", "")
+if API_KEY:
+    genai.configure(api_key=API_KEY)
+    gemini_model = genai.GenerativeModel("gemini-1.5-flash")
+else:
+    gemini_model = None
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+best_model = joblib.load("gradient_boosting_model.pkl")
+preprocessor = joblib.load("preprocessor.pkl")
+
+brands = ['Dacia', 'Renault', 'Peugeot', 'Hyundai', 'Volkswagen', 'Toyota', 'Fiat', 'Ford', 'Mercedes', 'BMW']
+car_parts = ['Porte arrière gauche', 'Aile arrière droite', 'Aile arrière gauche', 'Pare-brise arrière', 'Coffre', 'Feu arrière droit', 'Feu arrière gauche', 'Pare-choc arrière', "Plaque d'immatriculation arrière", 'Pare-choc avant', 'Capot', 'Grille', 'Phare avant gauche', 'Phare avant droit']
+car_parts_en = ['Left rear door', 'Right rear wing', 'Left rear wing', 'Rear windshield', 'Trunk', 'Right rear light', 'Left rear light', 'Rear bumper', 'Rear license plate', 'Front bumper', 'Hood', 'Grille', 'Left headlight', 'Right headlight']
+car_parts_map = dict(zip(car_parts, car_parts_en))
+
+class CarDetails(BaseModel):
+    brand: str
+    model: str
+    year: int
+    damaged_part: str
+    severity: int
+
+
+def analyze_image_with_gemini(image: Image.Image):
+    if not gemini_model:
+        raise RuntimeError("Gemini API key not configured")
+    prompt = """
+    Veuillez analyser cette image de voiture et extraire les informations suivantes :
+    - Marque et modèle de la voiture
+    - Année de fabrication estimée
+    - Partie endommagée
+    - Sévérité des dommages (répondez avec un nombre : 1 pour Mineur, 2 pour Modéré, 3 pour Grave)
+    - Brève description
+
+    Répondez en JSON :
+    {
+        "brand": "...",
+        "model": "...",
+        "year": 2020,
+        "damaged_part": "...",
+        "severity": 1,
+        "damage_description": "..."
+    }
+    """
+    img_bytes = io.BytesIO()
+    image.save(img_bytes, format=image.format or 'JPEG')
+    img_bytes = img_bytes.getvalue()
+    image_part = {"mime_type": "image/jpeg", "data": img_bytes}
+    response = gemini_model.generate_content([prompt, image_part])
+    match = re.search(r"\{.*\}", response.text, re.DOTALL)
+    if not match:
+        raise RuntimeError("Invalid response from Gemini")
+    result = json.loads(match.group(0))
+    return result
+
+
+@app.post("/predict")
+def predict(details: CarDetails):
+    data = pd.DataFrame([
+        {
+            "Brand": details.brand,
+            "Model": details.model,
+            "Year": details.year,
+            "Damaged_Part": details.damaged_part,
+            "Damage_Severity": details.severity,
+        }
+    ])
+    encoded = preprocessor.transform(data)
+    cost = best_model.predict(encoded)[0]
+    return {"estimated_cost": float(cost)}
+
+
+@app.post("/analyze")
+async def analyze(file: UploadFile = File(...)):
+    image = Image.open(io.BytesIO(await file.read()))
+    result = analyze_image_with_gemini(image)
+    # Compute cost with model
+    data = pd.DataFrame([
+        {
+            "Brand": result["brand"],
+            "Model": result["model"],
+            "Year": int(result["year"]),
+            "Damaged_Part": result["damaged_part"],
+            "Damage_Severity": int(result["severity"]),
+        }
+    ])
+    encoded = preprocessor.transform(data)
+    cost = best_model.predict(encoded)[0]
+    result["estimated_cost"] = float(cost)
+    return result
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Car Repair Cost Estimator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.15.0",
+    "@mui/icons-material": "^5.15.0",
+    "axios": "^1.6.8"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Container, Typography, Box } from '@mui/material';
+import CarForm from './components/CarForm';
+import ImageUpload from './components/ImageUpload';
+import CostDisplay from './components/CostDisplay';
+import axios from 'axios';
+
+const App = () => {
+  const [cost, setCost] = useState(null);
+  const [analysis, setAnalysis] = useState(null);
+
+  const handlePredict = async (data) => {
+    try {
+      const res = await axios.post('http://localhost:8000/predict', data);
+      setCost(res.data.estimated_cost);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleAnalyze = async (file) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const res = await axios.post('http://localhost:8000/analyze', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
+      setAnalysis(res.data);
+      setCost(res.data.estimated_cost);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Container maxWidth="md">
+      <Typography variant="h4" gutterBottom>
+        Car Repair Cost Estimator
+      </Typography>
+      <Box my={4}>
+        <CarForm onSubmit={handlePredict} />
+      </Box>
+      <Box my={4}>
+        <ImageUpload onAnalyze={handleAnalyze} />
+      </Box>
+      <Box my={4}>
+        <CostDisplay cost={cost} analysis={analysis} />
+      </Box>
+    </Container>
+  );
+};
+
+export default App;

--- a/frontend/src/components/CarForm.jsx
+++ b/frontend/src/components/CarForm.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { TextField, MenuItem, Button, Grid } from '@mui/material';
+
+const brands = ['Dacia','Renault','Peugeot','Hyundai','Volkswagen','Toyota','Fiat','Ford','Mercedes','BMW'];
+const models = {
+  Dacia: ['Logan','Sandero','Duster'],
+  Renault: ['Clio','Megane','Kangoo'],
+  Peugeot: ['208','301','308'],
+  Hyundai: ['i10','i20','Tucson'],
+  Volkswagen: ['Polo','Golf','Passat'],
+  Toyota: ['Yaris','Corolla','RAV4'],
+  Fiat: ['Panda','Tipo','500'],
+  Ford: ['Fiesta','Focus','EcoSport'],
+  Mercedes: ['C-Class','E-Class','A-Class'],
+  BMW: ['Series 1','Series 3','X1']
+};
+const parts = ['Porte arrière gauche','Aile arrière droite','Aile arrière gauche','Pare-brise arrière','Coffre','Feu arrière droit','Feu arrière gauche','Pare-choc arrière','Plaque d\'immatriculation arrière','Pare-choc avant','Capot','Grille','Phare avant gauche','Phare avant droit'];
+const severities = [
+  { value: 1, label: 'Mineur' },
+  { value: 2, label: 'Modéré' },
+  { value: 3, label: 'Grave' }
+];
+
+const CarForm = ({ onSubmit }) => {
+  const [brand, setBrand] = useState(brands[0]);
+  const [model, setModel] = useState(models[brands[0]][0]);
+  const [year, setYear] = useState(2020);
+  const [part, setPart] = useState(parts[0]);
+  const [severity, setSeverity] = useState(1);
+
+  const handleBrandChange = (e) => {
+    const value = e.target.value;
+    setBrand(value);
+    setModel(models[value][0]);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit({ brand, model, year, damaged_part: part, severity });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={6}>
+          <TextField select fullWidth label="Brand" value={brand} onChange={handleBrandChange}>
+            {brands.map((b) => (
+              <MenuItem key={b} value={b}>{b}</MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <TextField select fullWidth label="Model" value={model} onChange={(e) => setModel(e.target.value)}>
+            {models[brand].map((m) => (
+              <MenuItem key={m} value={m}>{m}</MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <TextField type="number" fullWidth label="Year" value={year} onChange={(e) => setYear(Number(e.target.value))} />
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <TextField select fullWidth label="Damaged Part" value={part} onChange={(e) => setPart(e.target.value)}>
+            {parts.map((p) => (
+              <MenuItem key={p} value={p}>{p}</MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <TextField select fullWidth label="Severity" value={severity} onChange={(e) => setSeverity(Number(e.target.value))}>
+            {severities.map((s) => (
+              <MenuItem key={s.value} value={s.value}>{s.label}</MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12}>
+          <Button variant="contained" color="primary" type="submit">
+            Get Estimate
+          </Button>
+        </Grid>
+      </Grid>
+    </form>
+  );
+};
+
+export default CarForm;

--- a/frontend/src/components/CostDisplay.jsx
+++ b/frontend/src/components/CostDisplay.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Typography, Box } from '@mui/material';
+
+const CostDisplay = ({ cost, analysis }) => {
+  if (cost === null) return null;
+  return (
+    <Box>
+      {analysis && (
+        <Box mb={2}>
+          <Typography>Brand: {analysis.brand}</Typography>
+          <Typography>Model: {analysis.model}</Typography>
+          <Typography>Year: {analysis.year}</Typography>
+          <Typography>Part: {analysis.damaged_part}</Typography>
+          <Typography>Severity: {analysis.severity}</Typography>
+        </Box>
+      )}
+      <Typography variant="h5">Estimated Cost: {cost} MAD</Typography>
+    </Box>
+  );
+};
+
+export default CostDisplay;

--- a/frontend/src/components/ImageUpload.jsx
+++ b/frontend/src/components/ImageUpload.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Button } from '@mui/material';
+
+const ImageUpload = ({ onAnalyze }) => {
+  const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState(null);
+
+  const handleChange = (e) => {
+    const f = e.target.files[0];
+    setFile(f);
+    if (f) {
+      setPreview(URL.createObjectURL(f));
+    }
+  };
+
+  const handleAnalyze = () => {
+    if (file) onAnalyze(file);
+  };
+
+  return (
+    <div>
+      <input type="file" accept="image/*" onChange={handleChange} />
+      {preview && (
+        <img src={preview} alt="preview" style={{ maxWidth: '100%', marginTop: '1rem' }} />
+      )}
+      <div>
+        <Button variant="outlined" onClick={handleAnalyze} sx={{ mt: 2 }}>
+          Analyze Image
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ImageUpload;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ Pillow==10.2.0
 plotly==5.18.0
 python-dotenv==1.0.1
 scikit-learn==1.6.1
+fastapi==0.110.0
+uvicorn==0.30.1
+python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- add FastAPI API with `/predict` and `/analyze` endpoints
- create React frontend (Vite + Material‑UI) for manual entry, image upload, and cost display
- document setup for API and frontend
- update dependencies

## Testing
- `python -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_685536fecbc88325b90cfebd7b955099